### PR TITLE
cs/fix/bulk zip empty

### DIFF
--- a/csv-bulk-signature/src/main.ts
+++ b/csv-bulk-signature/src/main.ts
@@ -142,9 +142,7 @@ async function zipUpFile() {
   const zip = new jszip();
 
   files.forEach(async (file) => {
-    const fileContents = await fs.promises.readFile(
-      `${SIGNATURES_PATH}/${file}`
-    );
+    const fileContents = fs.readFileSync(`${SIGNATURES_PATH}/${file}`);
     try {
       zip.file(file, fileContents);
     } catch (error: any) {


### PR DESCRIPTION
## overall purpose
Zip file was empty because `fs.promises.readFile()` gets file in chucks, where `fs.readFileSync()` gets the whole file.

## changes made
- change `fs.promise.readFile()` to `fs.readFileSync()`
- add error if zip file is empty in the future

## screenshot
![Screen Shot 2022-12-30 at 12 49 31 PM](https://user-images.githubusercontent.com/4466585/210103156-9fd5a2be-ac14-4b72-9c9c-06b9a404ef23.png)
