### PR TITLE
cs/refactor/bulk break up zip

### DIFF
--- a/csv-bulk-signature/src/main.test.ts
+++ b/csv-bulk-signature/src/main.test.ts
@@ -1,4 +1,9 @@
-import { filterFilesForZip, getFileName, getFullNameFileName } from "./main";
+import {
+  checkRequiredFields,
+  filterFilesForZip,
+  getFileName,
+  getFullNameFileName,
+} from "./main";
 import { Contact } from "./types";
 
 const contactGenerator: () => Contact = () => ({
@@ -70,4 +75,46 @@ describe("filterFilesForZip", () => {
     "ndodge.htm",
     "_statusReport.txt",
   ]);
+});
+
+describe("checkRequiredFields", () => {
+  it('should return "true" if all required fields are present', () => {
+    const result = checkRequiredFields(contactGenerator());
+
+    expect(result).toBe(true);
+  });
+
+  it('should return "false" if any required fields are missing', () => {
+    expect(
+      checkRequiredFields({
+        ...contactGenerator(),
+        // @ts-ignore - we're assuming Contact had missing data in runtime
+        "Brand*": undefined,
+      })
+    ).toBe(false);
+
+    expect(
+      checkRequiredFields({
+        ...contactGenerator(),
+        // @ts-ignore - we're assuming Contact had missing data in runtime
+        "Full Name*": undefined,
+      })
+    ).toBe(false);
+
+    expect(
+      checkRequiredFields({
+        ...contactGenerator(),
+        // @ts-ignore - we're assuming Contact had missing data in runtime
+        "Office Phone*": undefined,
+      })
+    ).toBe(false);
+
+    expect(
+      checkRequiredFields({
+        ...contactGenerator(),
+        // @ts-ignore - we're assuming Contact had missing data in runtime
+        "Title*": undefined,
+      })
+    ).toBe(false);
+  });
 });

--- a/csv-bulk-signature/src/main.test.ts
+++ b/csv-bulk-signature/src/main.test.ts
@@ -1,4 +1,4 @@
-import { getFileName, getFullNameFileName } from "./main";
+import { filterFilesForZip, getFileName, getFullNameFileName } from "./main";
 import { Contact } from "./types";
 
 const contactGenerator: () => Contact = () => ({
@@ -51,4 +51,23 @@ describe("getFileName", () => {
     const result = getFileName(contact);
     expect(result).toBe("jmichaeldoe");
   });
+});
+
+describe("filterFilesForZip", () => {
+  const files = [
+    ".gitkeep",
+    "acurl.htm",
+    "anitti.htm",
+    "ndodge.htm",
+    "_statusReport.txt",
+  ];
+
+  const result = files.filter(filterFilesForZip);
+
+  expect(result).toStrictEqual([
+    "acurl.htm",
+    "anitti.htm",
+    "ndodge.htm",
+    "_statusReport.txt",
+  ]);
 });

--- a/csv-bulk-signature/src/main.test.ts
+++ b/csv-bulk-signature/src/main.test.ts
@@ -39,7 +39,7 @@ describe("getFullNameFileName", () => {
 
 // test getFileName
 describe("getFileName", () => {
-  it("should return the correct file name", () => {
+  it("should return file name of first initial + last name", () => {
     const contact: Contact = {
       ...contactGenerator(),
       "Full Name*": "John Doe",

--- a/csv-bulk-signature/src/main.ts
+++ b/csv-bulk-signature/src/main.ts
@@ -220,6 +220,9 @@ function skipFirstPlaceholderRow(contact: Contact) {
   return contact["Brand*"] !== "use dropdown to select a brand";
 }
 
+export function filterFilesForZip(file: string) {
+  return file.endsWith(".htm") || file.endsWith(".txt");
+}
 /*
  * MAIN
  */
@@ -255,9 +258,7 @@ async function main() {
 
   // 6. gather files for zip
   const signatureFolder = await fs.readdir(SIGNATURES_PATH);
-  const files = signatureFolder.filter(
-    (file) => file.endsWith(".htm") || file.endsWith(".txt")
-  );
+  const files = signatureFolder.filter(filterFilesForZip);
 
   // 7. zip up files
   await zipUpFiles(files);

--- a/csv-bulk-signature/src/main.ts
+++ b/csv-bulk-signature/src/main.ts
@@ -223,6 +223,13 @@ function skipFirstPlaceholderRow(contact: Contact) {
 export function filterFilesForZip(file: string) {
   return file.endsWith(".htm") || file.endsWith(".txt");
 }
+
+export const checkRequiredFields = (row: Contact) =>
+  !!row["Brand*"]?.length &&
+  !!row["Full Name*"]?.length &&
+  !!row["Title*"]?.length &&
+  !!row["Office Phone*"]?.length;
+
 /*
  * MAIN
  */
@@ -238,12 +245,6 @@ async function main() {
   // 3. get contacts + filter
   const contacts = await getCSVRows(CSV_FILE);
   await checkHeadersToBeSame(contacts[0]);
-
-  const checkRequiredFields = (row: Contact) =>
-    !!row["Brand*"].length &&
-    !!row["Full Name*"].length &&
-    !!row["Title*"].length &&
-    !!row["Office Phone*"].length;
 
   const contactsWithNewProps = contacts
     .filter(skipFirstPlaceholderRow)


### PR DESCRIPTION
## overall
Zip file function does too many things. Plus, we don't have any tests surrounding files we expect fields we require.

## changes made
- breakup parts of creating zip file
- test what files we expect in zip
- test fields we expect to be required

## screenshot
![Screen Shot 2023-01-08 at 6 54 46 AM](https://user-images.githubusercontent.com/4466585/211197118-7a24b3bc-1ec4-4370-a071-799e6aaf2991.png)
